### PR TITLE
Added the get-all-tasklists endpoint, with tests

### DIFF
--- a/backend/src/controllers/tasklist.js
+++ b/backend/src/controllers/tasklist.js
@@ -33,6 +33,15 @@ const deleteTasklistSchema = {
 };
 
 /**
+ * @type {"import("jsonschema").Schema"}
+ */
+const getAllTasklistsSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {},
+};
+
+/**
  * Creates a new Tasklist
  *
  * @param {import("express").Request} req The incoming API request
@@ -100,7 +109,28 @@ const deleteTasklist = async (req, res) => {
   }
 };
 
+const getAllTasklists = async (req, res) => {
+  try {
+    const results = validateSchema(req.body, getAllTasklistsSchema);
+
+    if (!results.errors.length) {
+      const allTasklists = await Tasklist.find(
+        { owner: req.user.address },
+        "title"
+      );
+
+      return res.status(200).json(allTasklists).send();
+    }
+
+    return res.status(400).send();
+  } catch (err) {
+    console.log(err);
+    return res.status(500);
+  }
+};
+
 module.exports = {
   createTasklist,
   deleteTasklist,
+  getAllTasklists,
 };

--- a/backend/src/models/TaskList.js
+++ b/backend/src/models/TaskList.js
@@ -53,26 +53,6 @@ TaskListSchema.methods.getPublicFields = function () {
   return { _id, title, owner, order, tasks };
 };
 
-/** 
-TaskListSchema.post(
-  "findOneAndDelete",
-  { query: true, document: true },
-  async function (tasklist) {
-    try {
-      console.log(tasklist.tasks.length);
-      for (let i = 0; i < tasklist.tasks.length; i++) {
-        await this.model("TaskList").findByIdAndDelete({
-          _id: tasks[i],
-          owner: this.owner,
-        });
-      }
-    } catch (err) {
-      next(err);
-    }
-  }
-);
-*/
-
 const TaskList = mongoose.model("TaskList", TaskListSchema, "tasklists");
 
 module.exports = TaskList;

--- a/backend/src/routes/tasklist.js
+++ b/backend/src/routes/tasklist.js
@@ -17,4 +17,11 @@ router.post("/", tasklist.createTasklist);
  */
 router.delete("/remove", tasklist.deleteTasklist);
 
+/**
+ * API route "tasklist/allTasklists"
+ *
+ * Gets the titles of all the tasklists of a given owner
+ */
+router.get("/allTasklists", tasklist.getAllTasklists);
+
 module.exports = router;


### PR DESCRIPTION
Got rid of the schema thing we're tried to do from tasklist, added and tested the get all tasklists endpoint